### PR TITLE
Update download script, which was broken after a nextcloud update

### DIFF
--- a/checkpoints/download_checkpoints.sh
+++ b/checkpoints/download_checkpoints.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-curl --output checkpoints.tar https://syncandshare.desy.de/index.php/s/JYiSxBTo6FQGXqk/download\?path\=\&files\=checkpoints.tar
+curl --output checkpoints.tar https://syncandshare.desy.de/public.php/dav/files/HX388YZbjSGPNcC/?accept=zip
 tar -xvf checkpoints.tar
 rm -rf checkpoints.tar


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

- Updates the url in the checkpoint download script, since the old one was not working anymore after an update on the DESY nextcloud
